### PR TITLE
gallery/noise: Initial commit

### DIFF
--- a/gallery/noise/config.sh
+++ b/gallery/noise/config.sh
@@ -1,0 +1,10 @@
+# Config for the 'noise' screensaver
+
+# Name of the screensaver (12 chars max)
+name="noise"
+# Tagline for the screensaver (40 chars max)
+tagline="Retro CRT static noise screensaver"
+description="Relive the analog static noise of the yester-years."
+authors=""
+license="MIT"
+settings=""

--- a/gallery/noise/config.sh
+++ b/gallery/noise/config.sh
@@ -5,6 +5,6 @@ name="noise"
 # Tagline for the screensaver (40 chars max)
 tagline="Retro CRT static noise screensaver"
 description="Relive the analog static noise of the yester-years."
-authors=""
+authors="Rawiri Blundell"
 license="MIT"
 settings=""

--- a/gallery/noise/noise.sh
+++ b/gallery/noise/noise.sh
@@ -42,21 +42,23 @@ blocks=( "${block100}" "${block75}" "${block50}" "${block25}" "${block00}" )
 # This would allow desired behaviour to be selectable
 while true; do
   rand="${RANDOM}"
-
-  # Require range [0, 32766] to evenly divide by 2
-  # Reject 32767 to avoid modulo bias
-  if (( rand < 32767 )); then
-    result=$(( rand % 2 ))
+  # Require range [0, 32765] to evenly divide by 3
+  # Reject 32766 and 32767 to avoid modulo bias
+  if (( rand < 32766 )); then
+    result=$(( rand % 3 ))
     if (( result == 0 )); then
       # Black, white, greys from 256 ANSI set
-      color_set=( 0 7 8 15 16 145 188 {231..255} )  
-    else
+      color_set=( 0 7 8 15 16 145 188 {231..255} )
+    elif (( result == 1 )); then
       # Black, white, greys from 256 ANSI set, with RGBY thrown in
       color_set=( 0 7 8 15 16 145 188 {231..255} 196 46 21 226 )
+    else
+      # White only - uses faster emit_without_color()
+      color_set=( 15 )
     fi
     break
   fi
-  # If we're at this line, RANDOM hit 32767!
+  # If we're at this line, RANDOM hit 32766 or 32767!
 done
 
 tput setab 0 # black background
@@ -64,28 +66,64 @@ clear
 tput civis # no cursor
 
 # Initialise vars for batching
+# This eliminates "one pixel change per loop iteration"
+# Benchmarking led to a batch_size selection of 100
 buffer=""
 count=0
 batch_size=100
 
-while true; do
-  # Get random location and color
-  x=$(( ${SRANDOM:-$RANDOM} % width + 1 ))
-  y=$(( ${SRANDOM:-$RANDOM} % height + 1 ))
-  color_element=$(( ${SRANDOM:-$RANDOM} % ${#color_set[@]} ))
-  color_code="${color_set[color_element]}"
-  block_element=$(( ${SRANDOM:-$RANDOM} % ${#blocks[@]} ))
-  block=${blocks[block_element]}
+emit_with_color() {
+  while true; do
+    # Get random location and color
+    x=$(( ${SRANDOM:-$RANDOM} % width + 1 ))
+    y=$(( ${SRANDOM:-$RANDOM} % height + 1 ))
+    color_element=$(( ${SRANDOM:-$RANDOM} % ${#color_set[@]} ))
+    color_code="${color_set[color_element]}"
+    block_element=$(( ${SRANDOM:-$RANDOM} % ${#blocks[@]} ))
+    block=${blocks[block_element]}
 
-  # Build a buffer of changes to emit
-  buffer+="\e[${y};${x}H\e[38;5;${color_code}m${block}"
-  ((count++))
+    # Build a buffer of changes to emit
+    buffer+="\e[${y};${x}H\e[38;5;${color_code}m${block}"
+    ((count++))
 
-  # Once the buffer size meets the threshold, dump it and start again
-  if (( count >= batch_size )); then
-    printf -- '%b' "${buffer}"
-    buffer=""
-    count=0
-  fi
-done
+    # Once the buffer size meets the threshold, dump it and start again
+    if (( count >= batch_size )); then
+      printf -- '%b' "${buffer}"
+      buffer=""
+      count=0
+    fi
+  done
+}
 
+# In benchmarking, this performs 25-30% faster than emit_with_color()
+# Eliminating the rand calls for color selection clearly has an impact
+# Implicit trust of the terminal color state may have unpredictable results
+# At the end of the day, we're constrained by a shell loop
+# More performance could potentially be gleaned with parallelism (see: forkrun)
+emit_without_color() {
+  color_code="${color_set[*]}"
+  while true; do
+    # Get random location and color
+    x=$(( ${SRANDOM:-$RANDOM} % width + 1 ))
+    y=$(( ${SRANDOM:-$RANDOM} % height + 1 ))
+    block_element=$(( ${SRANDOM:-$RANDOM} % ${#blocks[@]} ))
+    block=${blocks[block_element]}
+
+    # Build a buffer of changes to emit
+    buffer+="\e[${y};${x}H\e[38;5;${color_code}m${block}"
+    ((count++))
+
+    # Once the buffer size meets the threshold, dump it and start again
+    if (( count >= batch_size )); then
+      printf -- '%b' "${buffer}"
+      buffer=""
+      count=0
+    fi
+  done
+}
+
+# Select our output method based on the size of ${color_set[@]}
+case "${#color_set[@]}" in
+  (1) emit_without_color ;;
+  (*) emit_with_color ;;
+esac

--- a/gallery/noise/noise.sh
+++ b/gallery/noise/noise.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Replicate old-school CRT static noise
+
+# Handler for SIGINT (Ctrl‑C)
+_handle_cleanup_and_exit() {
+  # show the cursor again
+  tput cnorm       
+  tput sgr0
+  echo
+  clear
+  exit 0
+}
+
+# Handler for SIGWINCH (window resize)
+_handle_window_resize() {
+  width="$(tput cols)"
+  height="$(tput lines)"
+  clear
+}
+
+# Capture Ctrl‑C
+trap _handle_cleanup_and_exit SIGINT 
+# Capture SIGWINCH
+trap _handle_window_resize SIGWINCH
+
+# Get terminal dimensions
+width="${COLUMNS:-$(tput cols)}"
+height="${LINES:-$(tput lines)}"
+
+# For portability, we use these UTF codes
+block100="\xe2\x96\x88"  # u2588\0xe2 0x96 0x88 Solid Block 100%
+block75="\xe2\x96\x93"   # u2593\0xe2 0x96 0x93 Dark shade 75%
+block50="\xe2\x96\x92"   # u2592\0xe2 0x96 0x92 Half shade 50%
+block25="\xe2\x96\x91"   # u2591\0xe2 0x96 0x91 Light shade 25%
+block00=' '              # Literal space
+
+blocks=( "${block100}" "${block75}" "${block50}" "${block25}" "${block00}" )
+
+# Randomly select one of the color sets
+# This could be moved to an arg in the future
+# or split to a separate screensaver
+# This would allow desired behaviour to be selectable
+while true; do
+  rand="${RANDOM}"
+
+  # Require range [0, 32766] to evenly divide by 2
+  # Reject 32767 to avoid modulo bias
+  if (( rand < 32767 )); then
+    result=$(( rand % 2 ))
+    if (( result == 0 )); then
+      # Black, white, greys from 256 ANSI set
+      color_set=( 0 7 8 15 16 145 188 {231..255} )  
+    else
+      # Black, white, greys from 256 ANSI set, with RGBY thrown in
+      color_set=( 0 7 8 15 16 145 188 {231..255} 196 46 21 226 )
+    fi
+    break
+  fi
+  # If we're at this line, RANDOM hit 32767!
+done
+
+tput setab 0 # black background
+clear
+tput civis # no cursor
+
+while true; do
+  # Get random location and color
+  x=$(( ${SRANDOM:-$RANDOM} % width + 1 ))
+  y=$(( ${SRANDOM:-$RANDOM} % height + 1 ))
+  color_element=$(( ${SRANDOM:-$RANDOM} % ${#color_set[@]} ))
+  color_code="${color_set[color_element]}"
+  block_element=$(( ${SRANDOM:-$RANDOM} % ${#blocks[@]} ))
+  block=${blocks[block_element]}
+
+  # Print the frame
+  printf -- '%b' "\e[${y};${x}H\e[38;5;${color_code}m${block}"
+done
+

--- a/gallery/noise/noise.sh
+++ b/gallery/noise/noise.sh
@@ -36,31 +36,6 @@ block00=' '              # Literal space
 
 blocks=( "${block100}" "${block75}" "${block50}" "${block25}" "${block00}" )
 
-# Randomly select one of the color sets
-# This could be moved to an arg in the future
-# or split to a separate screensaver
-# This would allow desired behaviour to be selectable
-while true; do
-  rand="${RANDOM}"
-  # Require range [0, 32765] to evenly divide by 3
-  # Reject 32766 and 32767 to avoid modulo bias
-  if (( rand < 32766 )); then
-    result=$(( rand % 3 ))
-    if (( result == 0 )); then
-      # Black, white, greys from 256 ANSI set
-      color_set=( 0 7 8 15 16 145 188 {231..255} )
-    elif (( result == 1 )); then
-      # Black, white, greys from 256 ANSI set, with RGBY thrown in
-      color_set=( 0 7 8 15 16 145 188 {231..255} 196 46 21 226 )
-    else
-      # White only - uses faster emit_without_color()
-      color_set=( 15 )
-    fi
-    break
-  fi
-  # If we're at this line, RANDOM hit 32766 or 32767!
-done
-
 tput setab 0 # black background
 clear
 tput civis # no cursor
@@ -73,6 +48,9 @@ count=0
 batch_size=100
 
 emit_with_color() {
+  local color_set x y color_element color_code
+  local block_element block buffer count batch_size
+  color_set=( 0 7 8 15 16 145 188 {231..255} 196 46 21 226 )
   while true; do
     # Get random location and color
     x=$(( ${SRANDOM:-$RANDOM} % width + 1 ))
@@ -95,13 +73,45 @@ emit_with_color() {
   done
 }
 
+# Uses direct color calculation instead of array lookup
+# Benchmarking shows ~11% improvement over emit_with_color()
+# Generates grey shades from ANSI 231-255 (25 shades)
+emit_with_simple_color() {
+  local x y color_code
+  local block_element block buffer count batch_size
+  while true; do
+    # Get random location
+    x=$(( ${SRANDOM:-$RANDOM} % width + 1 ))
+    y=$(( ${SRANDOM:-$RANDOM} % height + 1 ))
+
+    # Direct color calculation - no array needed
+    color_code=$(( 231 + ${SRANDOM:-$RANDOM} % 25 ))
+
+    block_element=$(( ${SRANDOM:-$RANDOM} % ${#blocks[@]} ))
+    block=${blocks[block_element]}
+
+    # Build a buffer of changes to emit
+    buffer+="\e[${y};${x}H\e[38;5;${color_code}m${block}"
+    ((count++))
+
+    # Once the buffer size meets the threshold, dump it and start again
+    if (( count >= batch_size )); then
+      printf -- '%b' "${buffer}"
+      buffer=""
+      count=0
+    fi
+  done
+}
+
 # In benchmarking, this performs 25-30% faster than emit_with_color()
 # Eliminating the rand calls for color selection clearly has an impact
 # Implicit trust of the terminal color state may have unpredictable results
 # At the end of the day, we're constrained by a shell loop
 # More performance could potentially be gleaned with parallelism (see: forkrun)
 emit_without_color() {
-  color_code="${color_set[*]}"
+  local x y color_code
+  local block_element block buffer count batch_size
+  color_code=15
   while true; do
     # Get random location and color
     x=$(( ${SRANDOM:-$RANDOM} % width + 1 ))
@@ -122,8 +132,29 @@ emit_without_color() {
   done
 }
 
-# Select our output method based on the size of ${color_set[@]}
-case "${#color_set[@]}" in
-  (1) emit_without_color ;;
-  (*) emit_with_color ;;
-esac
+# Randomly select one of the color modes
+# This could be moved to an arg in the future or split to separate screensavers
+# This would allow desired behaviour to be selectable
+while true; do
+  rand="${RANDOM}"
+  # Require range [0, 32765] to evenly divide by 3
+  # Reject 32766 and 32767 to avoid modulo bias
+  if (( rand < 32766 )); then
+    color_mode=$(( rand % 3 ))
+    case "${color_mode}" in
+      (0)
+        # Greys only - use simple direct calculation (fastest with color)
+        emit_with_simple_color
+      ;;
+      (1)
+        # Greys + accent colors - needs array lookup for RGBY
+        emit_with_color
+      ;;
+      (2)
+        # White only - uses emit_without_color (fastest overall)
+        emit_without_color
+      ;;
+    esac
+  fi
+  # If we're at this line, RANDOM hit 32766 or 32767!
+done

--- a/gallery/noise/noise.sh
+++ b/gallery/noise/noise.sh
@@ -63,6 +63,11 @@ tput setab 0 # black background
 clear
 tput civis # no cursor
 
+# Initialise vars for batching
+buffer=""
+count=0
+batch_size=100
+
 while true; do
   # Get random location and color
   x=$(( ${SRANDOM:-$RANDOM} % width + 1 ))
@@ -72,7 +77,15 @@ while true; do
   block_element=$(( ${SRANDOM:-$RANDOM} % ${#blocks[@]} ))
   block=${blocks[block_element]}
 
-  # Print the frame
-  printf -- '%b' "\e[${y};${x}H\e[38;5;${color_code}m${block}"
+  # Build a buffer of changes to emit
+  buffer+="\e[${y};${x}H\e[38;5;${color_code}m${block}"
+  ((count++))
+
+  # Once the buffer size meets the threshold, dump it and start again
+  if (( count >= batch_size )); then
+    printf -- '%b' "${buffer}"
+    buffer=""
+    count=0
+  fi
 done
 


### PR DESCRIPTION
Hi there,
I've thrown together this screensaver based loosely off the existing `stars` screensaver.

A few comments: We reduce a couple of potentially unnecessary external calls by using built-in vars, with external-call-fallbacks like so:

```
# Get terminal dimensions
width="${COLUMNS:-$(tput cols)}"
height="${LINES:-$(tput lines)}"
```

This gets the state that the script was launched within, but does not work reliably with SIGWINCH.  SIGWINCH should be rare anyway, we just eat the cost of a couple of `tput` calls.

(Noting that `tput` itself isn't 100% portable, but that only matters if you're running something like OpenBSD.)

We also lean on `SRANDOM` when it's available (bash 5.1+) and fall back to `RANDOM` when it's not.  I doubt there's any practical or appreciable difference, but logically we're pulling from the system entropy pool rather than `bash`'s croaky old LCG RNG, so that should scale better.  Hypothetically.  Maybe.

I initially had several selectable colour sets, but the addition of shading blocks enabled that to be compacted down.  Now it has two sets: greyscale or greyscale with some red, green, blue and yellow codes thrown in.

I use a slightly debiased modulo approach to provide a fair random selection between the two colour sets.  Here I just use `RANDOM` because `SRANDOM` is a sledgehammer for a one-off coin-toss.

Tested on `bash` 4 and 5 on Linux.  I don't have a Mac available to me, but I don't see anything that would upset `bash` 3.

Thanks!